### PR TITLE
Allow the use of async HTML renderers.

### DIFF
--- a/src/main/render/html/HtmlAsyncSubRenderer.ts
+++ b/src/main/render/html/HtmlAsyncSubRenderer.ts
@@ -1,0 +1,13 @@
+import {Node} from "../../Node";
+import {HtmlBuilder} from "./HtmlBuilder";
+
+export abstract class HtmlAsyncSubRenderer<NodeT extends Node> {
+    public readonly ctor : {new(...args : any[]):NodeT};
+    public constructor (ctor : {new(...args : any[]):NodeT}) {
+        this.ctor = ctor;
+    }
+    public canRender<OtherT extends Node> (node : OtherT) : this is HtmlAsyncSubRenderer<OtherT> {
+        return node instanceof this.ctor;
+    }
+    public abstract async renderAsync (builder : HtmlBuilder, node : NodeT, entering : boolean) : Promise<void>;
+}

--- a/src/main/render/html/HtmlRenderer.ts
+++ b/src/main/render/html/HtmlRenderer.ts
@@ -1,13 +1,14 @@
 import {Node} from "../../Node";
+import {HtmlAsyncSubRenderer} from "./HtmlAsyncSubRenderer";
 import {HtmlSubRenderer} from "./HtmlSubRenderer";
 import {HtmlBuilder} from "./HtmlBuilder";
 
 export class HtmlRenderer {
-    public subRenderers : HtmlSubRenderer<Node>[];
-    public constructor (subRenderers : HtmlSubRenderer<Node>[]) {
+    public subRenderers : HtmlAsyncSubRenderer<Node>[];
+    public constructor (subRenderers : HtmlAsyncSubRenderer<Node>[]) {
         this.subRenderers = subRenderers;
     }
-    public getSubRenderer<NodeT extends Node> (node : NodeT) : HtmlSubRenderer<NodeT> {
+    public getSubRenderer<NodeT extends Node> (node : NodeT) : HtmlAsyncSubRenderer<NodeT> {
         for (let sub of this.subRenderers) {
             if (sub.canRender(node)) {
                 return sub;
@@ -19,8 +20,17 @@ export class HtmlRenderer {
         const b = new HtmlBuilder();
         const w = node.walker();
         for (let event = w.next(); event != undefined; event = w.next()) {
-            const subRenderer = this.getSubRenderer(event.node);
+            const subRenderer = <HtmlSubRenderer<Node>>this.getSubRenderer(event.node);
             subRenderer.render(b, event.node, event.entering);
+        }
+        return b.toString();
+    }
+    public async renderAsync (node : Node) : Promise<string> {
+        const b = new HtmlBuilder();
+        const w = node.walker();
+        for (let event = w.next(); event != undefined; event = w.next()) {
+            const subRenderer = this.getSubRenderer(event.node);
+            await subRenderer.renderAsync(b, event.node, event.entering);
         }
         return b.toString();
     }

--- a/src/main/render/html/HtmlSubRenderer.ts
+++ b/src/main/render/html/HtmlSubRenderer.ts
@@ -1,13 +1,13 @@
 import {Node} from "../../Node";
 import {HtmlBuilder} from "./HtmlBuilder";
+import {HtmlAsyncSubRenderer} from "./HtmlAsyncSubRenderer";
 
-export abstract class HtmlSubRenderer<NodeT extends Node> {
-    public readonly ctor : {new(...args : any[]):NodeT};
+export abstract class HtmlSubRenderer<NodeT extends Node> extends HtmlAsyncSubRenderer<NodeT> {
     public constructor (ctor : {new(...args : any[]):NodeT}) {
-        this.ctor = ctor;
+        super(ctor);
     }
-    public canRender<OtherT extends Node> (node : OtherT) : this is HtmlSubRenderer<OtherT> {
-        return node instanceof this.ctor;
+    public async renderAsync (builder : HtmlBuilder, node : NodeT, entering : boolean) : Promise<void> {
+        await this.render(builder, node, entering);
     }
     public abstract render (builder : HtmlBuilder, node : NodeT, entering : boolean) : void;
 }


### PR DESCRIPTION
I wanted to create an HTML renderer that creates an image, based on a custom mark-down block. The generation of this image requires some async operations, so I think it would be a good idea to allow renderers to be async.

The API is still backwards compatible, but there is now an `renderAsync` method that allows the use of async renderers.

Unfortunately, I couldn't add test-cases for it, because I don't really know your testing framework. It doesn't seem to be able to deal with async test-cases.